### PR TITLE
Restore iOS compat <8 and >=8; Fix tests; 1 bug fix

### DIFF
--- a/TDOAuth.h
+++ b/TDOAuth.h
@@ -28,11 +28,15 @@
 */
 
 #import <Foundation/Foundation.h>
+#import <Availability.h>
 
 
 FOUNDATION_EXPORT double TDOAuthVersionNumber;
 FOUNDATION_EXPORT const unsigned char TDOAuthVersionString[];
 
+#if defined(__IPHONE_8_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_8_0)
+#define USE_NSURLCOMPONENTS
+#endif
 
 typedef NS_ENUM(NSInteger, TDOAuthSignatureMethod) {
     TDOAuthSignatureMethodHmacSha1,
@@ -79,6 +83,7 @@ typedef NS_ENUM(NSInteger, TDOAuthContentType) {
                         accessToken:(NSString *)accessToken
                         tokenSecret:(NSString *)tokenSecret;
 
+#ifdef USE_NSURLCOMPONENTS
 /**
   Allow to pass NSURLComponents. READ THE DOCUMENTATION IN PREVIOUS GET METHODS!
  */
@@ -87,7 +92,7 @@ typedef NS_ENUM(NSInteger, TDOAuthContentType) {
                                  consumerSecret:(NSString *)consumerSecret
                                     accessToken:(NSString *)accessToken
                                     tokenSecret:(NSString *)tokenSecret;
-
+#endif
 /**
   We always POST with HTTPS. This is because at least half the time the user's
   data is at least somewhat private, but also because apparently some carriers

--- a/TDOAuth.m
+++ b/TDOAuth.m
@@ -371,7 +371,7 @@ static NSString* timestamp() {
             if (error || !postbody) {
                 NSLog(@"Got an error encoding JSON: %@", error);
             } else {
-                [oauth setParameters:@[]]; // empty dictionary populates variables without putting data into the signature_base
+                [oauth setParameters:@[]]; // empty array populates variables without putting data into the signature_base
                 rq = [oauth requestWithHeaderValues:headerValues];
 
                 if (postbody.length) {

--- a/TDOAuth.podspec
+++ b/TDOAuth.podspec
@@ -7,10 +7,10 @@ Pod::Spec.new do |s|
   s.license = { :type => 'MIT', :text => 'OHAI CocoaPods linter!' }
   s.summary = 'Elegant, simple and tiny OAuth 1.x solution'
 
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '5.0'
   s.tvos.deployment_target = '11.0'
   s.watchos.deployment_target = '3.0'
-  s.osx.deployment_target = '10.10'
+  s.osx.deployment_target = '10.7'
 
   s.dependency 'OMGHTTPURLRQ/UserAgent'
   s.homepage = 'https://github.com/tweetdeck/TDOAuth'

--- a/Tests/MainTests.m
+++ b/Tests/MainTests.m
@@ -129,7 +129,7 @@
                                 "oauth_signature_method=\"HMAC-SHA1\", oauth_consumer_key=\"abcd\", "\
                                 "oauth_timestamp=\"1456789012\", oauth_version=\"1.0\", "\
                                 "oauth_signature=\"O4hspbDTqHlLdqfXxR0jSly9bkU%3D\"";
-    XCTAssert([authHeader isEqualToString:expectedHeader],
+    XCTAssertEqualObjects(authHeader, expectedHeader,
               @"Expected header value does does not match");
 }
 
@@ -195,7 +195,7 @@
     "oauth_signature_method=\"HMAC-SHA1\", oauth_consumer_key=\"abcd\", "\
     "oauth_timestamp=\"1456789012\", oauth_version=\"1.0\", "\
     "oauth_signature=\"pr%2ForWfyT9CsKTGW85AwjHmFjd8%3D\"";
-    XCTAssert([authHeader isEqualToString:expectedHeader],
+    XCTAssertEqualObjects(authHeader, expectedHeader,
               @"Expected header value does does not match");
 }
 
@@ -425,7 +425,7 @@
     "oauth_signature_method=\"HMAC-SHA1\", oauth_consumer_key=\"abcd\", "\
     "oauth_timestamp=\"1456789012\", oauth_version=\"1.0\", "\
     "oauth_signature=\"ycBj862NX5D9cCFrtWcBU2uzkdc%3D\"";
-    XCTAssert([authHeader isEqualToString:expectedHeader],
+    XCTAssertEqualObjects(authHeader, expectedHeader,
               @"Expected header value does does not match");
 }
 - (void)testGenericEncodesJson
@@ -448,7 +448,7 @@
     "oauth_signature_method=\"HMAC-SHA1\", oauth_consumer_key=\"abcd\", "\
     "oauth_timestamp=\"1456789012\", oauth_version=\"1.0\", "\
     "oauth_signature=\"%2FUo90sRcITkznrl9UoOqN8fCv40%3D\"";
-    XCTAssert([authHeader isEqualToString:expectedHeader],
+    XCTAssertEqualObjects(authHeader, expectedHeader,
               @"Expected header value does does not match");
 }
 - (void)testGenericRecognizesSHA256
@@ -471,7 +471,7 @@
     "oauth_signature_method=\"HMAC-SHA256\", oauth_consumer_key=\"abcd\", "\
     "oauth_timestamp=\"1456789012\", oauth_version=\"1.0\", "\
     "oauth_signature=\"pRxssqcfFnrUqF7i2L5j%2BpCk57gu33m3c9az5kNGors%3D\"";
-    XCTAssert([authHeader isEqualToString:expectedHeader],
+    XCTAssertEqualObjects(authHeader, expectedHeader,
               @"Expected header value does does not match");
 }
 - (void)testGenericRejectsInvalidSignatureMethod


### PR DESCRIPTION
-  fixes the tests (by fixing the parameter ordering)
- fixes 1 crash bug (missing `mutableCopy`)
- puts all the `NSURLQueryItem` and `NSURLComponents` behind iOS 8+ macro

This would prevent cutting off old versions. I am happy to do a major release shortly after where the iOS version is bumped to 8 and the use of `TDQueryItem` is removed completely.